### PR TITLE
Add tagtorg command

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Tim Stuart
+Copyright (c) 2020 Tim Stuart, Warren W. Kretzschmar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@ Sinto is a toolkit for processing aligned single-cell data. Sinto includes funct
 - Subset reads from a BAM file by cell barcode
 - Create a scATAC-seq fragments file from a BAM file
 - Add read tags to a BAM file according to cell barcode information
+- Add read groups based on read tags
 
 Read the documentation at https://timoast.github.io/sinto
 

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -309,7 +309,7 @@ Then we can replace the read groups in the SAM file using the command:
 
 .. code-block::
 
-    sinto addtorg -b input.sam -f barcodes.txt
+    sinto tagtorg -b input.sam -f barcodes.txt
 
 This will print the following SAM file to screen:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'sinto'
-copyright = '2020, Tim Stuart'
+copyright = '2020, Tim Stuart, Warren W. Kretzschmar'
 author = 'Tim Stuart'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,3 +13,12 @@ Install from source:
     git clone https://github.com/timoast/sinto.git
     cd sinto
     python setup.py install
+
+
+Testing
+-------
+
+::
+
+    pip install pytest
+    pytest

--- a/scripts/sinto
+++ b/scripts/sinto
@@ -112,6 +112,51 @@ parser_addtags.add_argument(
 )
 parser_addtags.set_defaults(func=cli.run_addtags)
 
+# tagtorg
+parser_tagtorg = subparsers.add_parser(
+    "tagtorg",
+    description="Append a read tag to the read group ID of each read. "
+    "Also appends the read tag to the SM field of the read group.",
+)
+parser_tagtorg.add_argument(
+    "-b",
+    "--bam",
+    help="Input SAM/BAM file, '-' reads from stdin",
+    required=True,
+    type=str,
+)
+parser_tagtorg.add_argument(
+    "--tag",
+    help="Read tag to extract the value from that is appended to the read group. "
+    "Default is 'CB', the tag that is used in 10x sequencing to identify cells.",
+    default="CB",
+    type=str,
+)
+parser_tagtorg.add_argument(
+    "-f",
+    "--tagfile",
+    help="List of expected tag values. Reads with tag values that are not in this list are not altered.",
+    required=True,
+    type=str,
+)
+parser_tagtorg.add_argument(
+    "-o",
+    "--output",
+    help="Output SAM/BAM file, '-' outputs to stdout (default '-')",
+    default="-",
+    type=str,
+)
+parser_tagtorg.add_argument(
+    "-O",
+    "--outputformat",
+    help="Output format. One of 't' (SAM), 'b' (BAM),"
+    " or 'u' (uncompressed BAM) ('t' default)",
+    default="t",
+)
+
+
+parser_tagtorg.set_defaults(func=cli.run_tagtorg)
+
 # fragments
 parser_fragments = subparsers.add_parser(
     "fragments", description="Create ATAC-seq fragment file from BAM file"
@@ -195,7 +240,7 @@ parser_fragments.add_argument(
     """,
     required=False,
     default=5000,
-    type=int
+    type=int,
 )
 parser_fragments.add_argument(
     "--chunksize",
@@ -205,7 +250,7 @@ parser_fragments.add_argument(
     """,
     required=False,
     default=500000,
-    type=int
+    type=int,
 )
 parser_fragments.set_defaults(func=cli.run_fragments)
 

--- a/sinto/cli.py
+++ b/sinto/cli.py
@@ -1,4 +1,4 @@
-from sinto import utils, filterbarcodes, addtags, fragments
+from sinto import utils, filterbarcodes, addtags, fragments, tagtorg
 
 
 @utils.log_info
@@ -11,7 +11,7 @@ def run_filterbarcodes(options):
         trim_suffix=options.trim_suffix,
         nproc=options.nproc,
         readname_barcode=options.barcode_regex,
-        cellbarcode=options.barcodetag
+        cellbarcode=options.barcodetag,
     )
 
 
@@ -29,6 +29,7 @@ def run_addtags(options):
         mode=options.mode,
     )
 
+
 @utils.log_info
 def run_fragments(options):
     """Wraps the sctools.fragments function for use on the command line
@@ -43,5 +44,15 @@ def run_fragments(options):
         chromosomes=options.use_chrom,
         cells=options.cells,
         max_distance=options.max_distance,
-        chunksize=options.chunksize
+        chunksize=options.chunksize,
+    )
+
+
+def run_tagtorg(options):
+    tagtorg.tagtorg(
+        bam=options.bam,
+        tag_value_file=options.tagfile,
+        tag=options.tag,
+        output=options.output,
+        out_format=options.outputformat,
     )

--- a/sinto/tagtorg.py
+++ b/sinto/tagtorg.py
@@ -1,0 +1,69 @@
+import sys
+from contextlib import closing
+
+import pysam
+
+
+def header_line_to_str(line):
+    return "\t".join(f"{k}:{v}" for k, v in line.items())
+
+
+def build_header(header, tag_vals):
+    new_rg_lines = []
+    for val in tag_vals:
+        for rg in header["RG"]:
+            rg = rg.copy()
+            rg["SM"] += f":{val}"
+            rg["ID"] += f":{val}"
+            new_rg_lines.append("@RG\t" + header_line_to_str(rg))
+    return str(header) + "\n".join(new_rg_lines) + "\n"
+
+
+OUT_FORMAT_CONVERSION = {
+    "t": "",
+    "b": "b",
+    "u": "bu",
+}
+
+
+def tagtorg(bam, tag, output, tag_value_file, out_format="t"):
+    """Add tags to reads from individual cells
+
+    Copies BAM entries to a new file, adding a read tag to cells matching an input table
+
+    Parameters
+    ----------
+    bam : str
+        Path to SAM/BAM file, or "-" to read from stdin.
+    tag_value_file : str
+        Text file with one line per expected tag value.
+    output : str
+        Name for output SAM/BAM file, or "-" to write to stdout.
+    out_format : str
+        One of "t" (SAM), "b" (BAM), or "u" (uncompressed BAM) ("t" default)
+    """
+
+    infile = pysam.AlignmentFile(bam, "r")
+    with open(tag_value_file) as fh:
+        tag_vals = {val.rstrip() for val in fh.readlines()}
+    new_header = build_header(infile.header, tag_vals)
+
+    outfile = pysam.AlignmentFile(
+        output, "w" + OUT_FORMAT_CONVERSION[out_format], text=new_header
+    )
+    with closing(outfile) as outfile:
+        for rec in infile:
+            try:
+                tag_val = rec.get_tag(tag)
+            except KeyError:
+                pass
+            else:
+                if tag_val in tag_vals:
+                    rec.set_tag(
+                        "RG",
+                        f"{rec.get_tag('RG')}:{tag_val}",
+                        value_type="Z",
+                        replace=True,
+                    )
+            finally:
+                outfile.write(rec)

--- a/tests/test_tag_to_rg.py
+++ b/tests/test_tag_to_rg.py
@@ -1,0 +1,74 @@
+import subprocess
+
+
+def test_adds_CB_tag_to_rg(tmpdir):
+
+    # given
+    # modified from an example in the SAM specification v1
+    sam = (
+        "@HD VN:1.5 SO:coordinate\n"
+        "@SQ SN:20 LN:63025520\n"
+        "@RG ID:rg1 SM:sample_1 LB:1 PU:1 PL:ILLUMINA\n"
+        "r002 0 20 9 30 3S6M1P1I4M * 0 0 AAAAGATAAGGATA * CB:Z:AAAA-1 RG:Z:rg1\n"
+    ).replace(" ", "\t")
+    in_sam_file = tmpdir / "in.sam"
+    in_tag_file = tmpdir / "tags.txt"
+    output = tmpdir/'output.sam'
+    with open(in_sam_file, "w") as fh:
+        fh.write(sam)
+    with open(in_tag_file, "w") as fh:
+        fh.write("AAAA-1")
+
+    # when
+    subprocess.run(
+        f"sinto tagtorg --tagfile {in_tag_file} --tag CB -b - -o - < {in_sam_file} > {output}",
+        shell=True,
+    )
+
+    # then
+    out_sam = open(output).read()
+    expected = (
+        "@HD VN:1.5 SO:coordinate\n"
+        "@SQ SN:20 LN:63025520\n"
+        "@RG ID:rg1 SM:sample_1 LB:1 PU:1 PL:ILLUMINA\n"
+        "@RG ID:rg1:AAAA-1 SM:sample_1:AAAA-1 LB:1 PU:1 PL:ILLUMINA\n"
+        "r002 0 20 9 30 3S6M1P1I4M * 0 0 AAAAGATAAGGATA * CB:Z:AAAA-1 RG:Z:rg1:AAAA-1\n"
+    ).replace(" ", "\t")
+    assert expected == out_sam
+
+def test_ignores_unknown_cb_tag(tmpdir):
+
+    # given
+    # modified from an example in the SAM specification v1
+    sam = (
+        "@HD VN:1.5 SO:coordinate\n"
+        "@SQ SN:20 LN:63025520\n"
+        "@RG ID:rg1 SM:sample_1 LB:1 PU:1 PL:ILLUMINA\n"
+        "r002 0 20 9 30 3S6M1P1I4M * 0 0 AAAAGATAAGGATA * CB:Z:AAAA-1 RG:Z:rg1\n"
+        "r002 0 20 9 30 3S6M1P1I4M * 0 0 AAAAGATAAGGATA * CB:Z:CCCC-1 RG:Z:rg1\n"
+    ).replace(" ", "\t")
+    in_sam_file = tmpdir / "in.sam"
+    in_tag_file = tmpdir / "tags.txt"
+    output = tmpdir/'output.sam'
+    with open(in_sam_file, "w") as fh:
+        fh.write(sam)
+    with open(in_tag_file, "w") as fh:
+        fh.write("AAAA-1")
+
+    # when
+    subprocess.run(
+        f"sinto tagtorg --tagfile {in_tag_file} --tag CB -b - -o - < {in_sam_file} > {output}",
+        shell=True,
+    )
+
+    # then
+    out_sam = open(output).read()
+    expected = (
+        "@HD VN:1.5 SO:coordinate\n"
+        "@SQ SN:20 LN:63025520\n"
+        "@RG ID:rg1 SM:sample_1 LB:1 PU:1 PL:ILLUMINA\n"
+        "@RG ID:rg1:AAAA-1 SM:sample_1:AAAA-1 LB:1 PU:1 PL:ILLUMINA\n"
+        "r002 0 20 9 30 3S6M1P1I4M * 0 0 AAAAGATAAGGATA * CB:Z:AAAA-1 RG:Z:rg1:AAAA-1\n"
+        "r002 0 20 9 30 3S6M1P1I4M * 0 0 AAAAGATAAGGATA * CB:Z:CCCC-1 RG:Z:rg1\n"
+    ).replace(" ", "\t")
+    assert expected == out_sam


### PR DESCRIPTION
Here is the implementation of the feature briefly described in #8.

The `tagtorg` command allows replacing RG tags with read tag-specific tags. This is done in a single pass and without creating files other than the output file.

I have tried to follow the conventions in the code as much as possible, but I broke with one point of sinto code style and coded the command to follow the UNIX convention of being able to read data from stdin and output results to stdout.  I allow the specification of a dash `-` to indicate this. 

I use pysam to parse the input and write the output data. Pysam allows reading of SAM and BAM formatted data and allows the output of SAM, compressed BAM, and uncompressed BAM. As these features come for free with pysam, this command also provides them. In practice I find a substantial speedup when I output uncompressed BAM to stdout and let samtools compress it in a later stage of a (UNIX) pipeline.