### PR TITLE
Use SAM/BAM opening idiom recommended by pysam

### DIFF
--- a/sinto/tagtorg.py
+++ b/sinto/tagtorg.py
@@ -37,7 +37,7 @@ def tagtorg(bam, tag, output, tag_value_file, out_format="t"):
         One of "t" (SAM), "b" (BAM), or "u" (uncompressed BAM) ("t" default)
     """
 
-    infile = pysam.AlignmentFile(bam, "r")
+    infile = pysam.AlignmentFile(bam)
     with open(tag_value_file) as fh:
         tag_vals = {val.rstrip() for val in fh.readlines()}
     new_header = build_header(infile.header, tag_vals)

--- a/sinto/tagtotag.py
+++ b/sinto/tagtotag.py
@@ -36,7 +36,7 @@ def tagtotag(
     assert len(from_tag) == 2
     assert len(to_tag) == 2
 
-    infile = pysam.AlignmentFile(bam, "r")
+    infile = pysam.AlignmentFile(bam)
     outfile = pysam.AlignmentFile(
         output, "w" + OUT_FORMAT_CONVERSION[out_format], template=infile
     )

--- a/sinto/tagtotag.py
+++ b/sinto/tagtotag.py
@@ -36,11 +36,7 @@ def tagtotag(
     assert len(from_tag) == 2
     assert len(to_tag) == 2
 
-    if bam.endswith(".bam"):
-        infile = pysam.AlignmentFile(bam, "rb")
-    else:
-        infile = pysam.AlignmentFile(bam, "r")
-    
+    infile = pysam.AlignmentFile(bam, "r")
     outfile = pysam.AlignmentFile(
         output, "w" + OUT_FORMAT_CONVERSION[out_format], template=infile
     )

--- a/tests/test_tag_to_tag.py
+++ b/tests/test_tag_to_tag.py
@@ -46,3 +46,36 @@ def test_copies_CB_tag_to_cb(tmpdir, delete):
     expected = expected.replace(" ", "\t")
     assert expected == out_sam
 
+def test_copies_CB_tag_to_cb_from_bam(tmpdir):
+
+    # given
+    # modified from an example in the SAM specification v1
+    sam = (
+        "@HD VN:1.5 SO:coordinate\n"
+        "@SQ SN:20 LN:63025520\n"
+        "r002 0 20 9 30 3S6M1P1I4M * 0 0 AAAAGATAAGGATA * CB:Z:AAAA-1\n"
+    ).replace(" ", "\t")
+    in_sam_file = tmpdir / "in.sam"
+    in_tag_file = tmpdir / "tags.txt"
+    output = tmpdir / "output.sam"
+    with open(in_sam_file, "w") as fh:
+        fh.write(sam)
+    with open(in_tag_file, "w") as fh:
+        fh.write("AAAA-1")
+    subprocess.run(f"samtools view {in_sam_file} -OBAM -o {in_sam_file}.binary-sam", shell=True)
+
+    # when
+    cmd = f"sinto tagtotag --from CB --to xx --bam - -o -"
+    cmd += f" < {in_sam_file}.binary-sam > {output}"
+    subprocess.run(cmd, shell=True)
+
+    # then
+    out_sam = open(output).read()
+    expected = (
+        "@HD VN:1.5 SO:coordinate\n"
+        "@SQ SN:20 LN:63025520\n"
+        "r002 0 20 9 30 3S6M1P1I4M * 0 0 AAAAGATAAGGATA * CB:Z:AAAA-1 xx:Z:AAAA-1\n"
+    )
+    expected = expected.replace(" ", "\t")
+    assert expected == out_sam
+


### PR DESCRIPTION
pysam can figure out whether an input file is SAM, BAM, or CRAM, and open it accordingly (https://pysam.readthedocs.io/en/latest/api.html#pysam.AlignmentFile). Although using `mode="r"` works just fine according to my test, the idiom recommended by the `pysam` documentation is to simply not provide a file mode when opening files, and the `AlignmentFile` object will figure out the type by itself. This PR makes that adjustment.