### PR TITLE
Specify a whitelist when adding barcodes

### DIFF
--- a/sinto/addbarcodes.py
+++ b/sinto/addbarcodes.py
@@ -40,7 +40,7 @@ def addbarcodes(cb_position, fq1, fq2, fq3=None, prefix="", suffix="", wl=None):
     suffix : str
         Suffix to append to cell barcodes
     """
-    barcodes, whitelist = get_barcodes(f=fq1, bases=cb_position, prefix=prefix, suffix=suffix, wl=None)
+    barcodes, whitelist = get_barcodes(f=fq1, bases=cb_position, prefix=prefix, suffix=suffix, wl=wl)
     if len(whitelist) > 0:
         barcodes = correct_barcodes(barcodes, whitelist)
     add_barcodes(f=fq2, cb=barcodes)

--- a/sinto/addbarcodes.py
+++ b/sinto/addbarcodes.py
@@ -16,7 +16,7 @@ def correct_barcodes(barcodes, whitelist):
             H = [hamming(bc, x) for x in whitelist]
             m = min(H)
             if m < 2:
-                corrected[bc] = [wl[x] for x in range(len(whitelist)) if H[x] == m][0]
+                corrected[bc] = [whitelist[x] for x in range(len(whitelist)) if H[x] == m][0]
             else:
                 # no bc in whitelist, keep this
                 corrected[bc] = bc

--- a/sinto/arguments.py
+++ b/sinto/arguments.py
@@ -457,6 +457,9 @@ parser_barcode.add_argument(
 parser_barcode.add_argument(
     "--suffix", help="Suffix to add to cell barcodes", required=False, type=str, default=""
 )
+parser_barcode.add_argument(
+    "--whitelist", help="Text file containing barcode whitelist", required=False, type=str, default=None
+)
 parser_barcode.set_defaults(func=cli.run_barcode)
 
 # tagtoname

--- a/sinto/cli.py
+++ b/sinto/cli.py
@@ -109,6 +109,7 @@ def run_barcode(options):
         fq3=options.read2,
         prefix=options.prefix,
         suffix=options.suffix,
+        wl=options.whitelist,
     )
 
 @utils.log_info


### PR DESCRIPTION
Hello, following up issue #60 I've added the possibility to specify a whitelist to the `barcode` predicate. This may be useful if one doesn't want to create an extra fastq file containing the corrected barcodes, hence saving some disk space (also considering the fact it is recommended to use uncompressed fastqs).
If no whitelist is specified nothing changes. Otherwise one can supply either a whitelist from UMI-tools or a generic whitelist. In the first case it will be directly used to correct barcodes whenever possible, without checks. In the second case it will make use of of [UMI-tools API](https://umi-tools.readthedocs.io/en/latest/API.html#the-umiclusterer-class) and will correct barcodes on the fly.
If correction is made on the fly, an extra time will be needed to process data, much depending on the fastq size  