### PR TITLE
fix NoneType errors

### DIFF
--- a/sinto/addbarcodes.py
+++ b/sinto/addbarcodes.py
@@ -97,7 +97,7 @@ def addbarcodes(cb_position, fq1, fq2, fq3=None, prefix="", suffix="", wl=None):
         Suffix to append to cell barcodes
     """
     barcodes, whitelist = get_barcodes(f=fq1, bases=cb_position, prefix=prefix, suffix=suffix, wl=wl)
-    if len(whitelist) > 0:
+    if whitelist and len(whitelist) > 0:
         barcodes = correct_barcodes(barcodes, whitelist)
     add_barcodes(f=fq2, cb=barcodes)
     if fq3 is not None:


### PR DESCRIPTION
Fix the following error:

```

barcode_fastq	barcodes.fastq.gz
read1	read1.fastq.gz
read2	None
bases	16
prefix	
suffix	
whitelist	None
func	<function run_barcode at 0x7f50f63389d0>
Traceback (most recent call last):
  File "/usr/local/bin/sinto", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/site-packages/sinto/arguments.py", line 555, in main
    options.func(options)
  File "/usr/local/lib/python3.10/site-packages/sinto/utils.py", line 24, in wrapper
    func(args)
  File "/usr/local/lib/python3.10/site-packages/sinto/cli.py", line 105, in run_barcode
    addbarcodes.addbarcodes(
  File "/usr/local/lib/python3.10/site-packages/sinto/addbarcodes.py", line 100, in addbarcodes
    if len(whitelist) > 0:
TypeError: object of type 'NoneType' has no len()